### PR TITLE
Fix: IsRunning() should return true when peer.stop is false

### DIFF
--- a/pfcp/peer.go
+++ b/pfcp/peer.go
@@ -132,7 +132,7 @@ func (peer *PFCPPeer) loopUnwrapped() {
 }
 
 func (peer *PFCPPeer) IsRunning() bool {
-	return peer.stop
+	return !peer.stop
 }
 
 // Close connection of PFCPPeer


### PR DESCRIPTION
semantics of peer.stop and IsRunning are opposite