### PR TITLE
peer.IsRunning and peer.stop have opposite semantics

### DIFF
--- a/pfcp/peer.go
+++ b/pfcp/peer.go
@@ -132,7 +132,7 @@ func (peer *PFCPPeer) loopUnwrapped() {
 }
 
 func (peer *PFCPPeer) IsRunning() bool {
-	return peer.stop
+	return !peer.stop
 }
 
 // Close connection of PFCPPeer


### PR DESCRIPTION
peer.IsRunning should be true when peer.stop is false